### PR TITLE
Bump jest version to 19.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "gzip-size": "3.0.0",
     "html-webpack-plugin": "2.24.0",
     "http-proxy-middleware": "0.17.2",
-    "jest": "18.1.0",
+    "jest": "~19.0.0",
     "json-loader": "0.5.4",
     "object-assign": "4.1.0",
     "path-exists": "2.1.0",


### PR DESCRIPTION
In package.json, the `testMatch` Jest config option is used, but that option wasn't added until v19 (https://facebook.github.io/jest/docs/en/configuration.html#testmatch-array-string). This prevents `npm test` from running `scripts/test.js` as a test, since it matches the default. The test always fails due to redeclaration of `jest`).